### PR TITLE
Changes for GuardDuty already being provisioned

### DIFF
--- a/modules/account-baseline/guardduty.tf
+++ b/modules/account-baseline/guardduty.tf
@@ -1,6 +1,7 @@
 module "baseline_guardduty" {
   source                            = "./modules/baseline-guardduty"
   resource_name_prefix              = var.resource_name_prefix
+  provision_guardduty_detector      = var.provision_guardduty_detector
   sl_firehose_destination_guardduty = var.sl_firehose_destination_guardduty
   tags                              = var.tags
 }

--- a/modules/account-baseline/modules/baseline-guardduty/guardduty.tf
+++ b/modules/account-baseline/modules/baseline-guardduty/guardduty.tf
@@ -1,4 +1,5 @@
 resource "aws_guardduty_detector" "this" {
+  count                        = var.provision_guardduty_detector ? 1 : 0
   enable                       = var.enable_collector
   finding_publishing_frequency = var.publishing_frequency
   tags                         = var.tags

--- a/modules/account-baseline/modules/baseline-guardduty/variables.tf
+++ b/modules/account-baseline/modules/baseline-guardduty/variables.tf
@@ -22,7 +22,7 @@ variable "enable_collector" {
 }
 
 variable "provision_guardduty_detector" {
-  type = string
+  type    = string
   default = true
 }
 

--- a/modules/account-baseline/modules/baseline-guardduty/variables.tf
+++ b/modules/account-baseline/modules/baseline-guardduty/variables.tf
@@ -21,6 +21,10 @@ variable "enable_collector" {
   default     = true
 }
 
+variable "provision_guardduty_detector" {
+  type = string
+  default = true
+}
 
 variable "publishing_frequency" {
   type        = string

--- a/modules/account-baseline/variables.tf
+++ b/modules/account-baseline/variables.tf
@@ -12,6 +12,10 @@ variable "sl_firehose_destination_guardduty" {
   type = string
 }
 
+variable "provision_guardduty_detector" {
+  type = string
+  default = true
+}
 
 variable "tags" {
   type        = map(string)

--- a/modules/account-baseline/variables.tf
+++ b/modules/account-baseline/variables.tf
@@ -13,7 +13,7 @@ variable "sl_firehose_destination_guardduty" {
 }
 
 variable "provision_guardduty_detector" {
-  type = string
+  type    = string
   default = true
 }
 


### PR DESCRIPTION
Originally, when MoJ provisioned an AWS account, it didn't have a GuardDuty detector, so we created one.

Now, newly provisioned AWS accounts come with GuardDuty, and if we tried to apply the baseline module, we'd get

```
Error: Creating GuardDuty Detector failed: BadRequestException: The request is rejected because a detector already exists for the current account.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "fe6dbcb0-2b9b-4770-b276-c13cb2b4f0a1"
  },
  Message_: "The request is rejected because a detector already exists for the current account.",
  Type: "InvalidInputException"
}
```

However, we still want all the surrounding resources so we can ship GuardDuty findings to QQ's SIEM