### PR TITLE
ELM-501: Stop using MFA_plus_sec for human users

### DIFF
--- a/modules/standard-user/variables.tf
+++ b/modules/standard-user/variables.tf
@@ -58,7 +58,6 @@ locals {
     }
   )
   default_group_membership = [
-    "MFA_plus_sec",
     "hmpps-mfa-users-group"
   ]
   group_membership = concat(local.default_group_membership, var.group_membership)


### PR DESCRIPTION
Currently every user is added to a minimum of 2 groups:
- hmpps-mfa-users-group
- MFA_plus_sec

hmpps-mfa-users-group is managed in terraform. MFA_plus_sec is managed in an old cloudformation stack

hmpps-mfa-users-group has 5 policies attached which are (nearly) duplicates of the 5 policies attached to the MFA_plus_sec.
- `aws-iam-user-selfservice-policy` is the same as `hmpps-user-selfservice-group-policy` (prior to recent work done by Adrian)
- `enforce_mfa` is the same as `hmpps-mfa-group-policy`
- `deny_all_outside_eu` is the same as `hmpps-deny-all-outside-eu-group-policy` (prior to recent work by James)
- `billing-deny-write-policy` is the same as `hmpps-billing-deny-write-group-policy`
- Both have `IAMUserChangePassword` AWS managed policy attached