### PR TITLE
ELM-1513: Bugfix where default values cannot be empty. Workaround to add content

### DIFF
--- a/modules/standard-user/variables.tf
+++ b/modules/standard-user/variables.tf
@@ -25,7 +25,7 @@ variable "email" {
 variable "cjsm_email" {
   type        = string
   description = "The users cjsm email address. Used for sending credentials."
-  default     = ""
+  default     = "Unknown or to be confirmed"
 }
 
 


### PR DESCRIPTION
Known terraform issue. See https://github.com/hashicorp/terraform-provider-aws/issues/31941