### PR TITLE
ELM-1137: Create standardised module for S3 object created queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.terraform
+.terraform.lock.hcl

--- a/modules/bucket-notification-queue/main.tf
+++ b/modules/bucket-notification-queue/main.tf
@@ -1,0 +1,11 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_sqs_queue" "this" {
+  name = var.queue_name
+  tags = var.tags
+}
+
+resource "aws_sqs_queue_policy" "this" {
+  queue_url = aws_sqs_queue.this.id
+  policy    = data.aws_iam_policy_document.this.json
+}

--- a/modules/bucket-notification-queue/outputs.tf
+++ b/modules/bucket-notification-queue/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  value       = aws_sqs_queue.this.arn
+  description = "The arn of the queue created by this module."
+}

--- a/modules/bucket-notification-queue/outputs.tf
+++ b/modules/bucket-notification-queue/outputs.tf
@@ -1,4 +1,4 @@
-output "arn" {
-  value       = aws_sqs_queue.this.arn
-  description = "The arn of the queue created by this module."
+output "queue" {
+  value       = aws_sqs_queue.this
+  description = "The attributes of the queue created by this module."
 }

--- a/modules/bucket-notification-queue/policy.tf
+++ b/modules/bucket-notification-queue/policy.tf
@@ -1,0 +1,60 @@
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid = "AllowBucketToPubishEvents"
+
+    actions = [
+      "SQS:SendMessage"
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "s3.amazonaws.com"
+      ]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        var.publishing_bucket_arn
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        data.aws_caller_identity.current.account_id
+      ]
+    }
+
+    resources = [
+      aws_sqs_queue.this.arn
+    ]
+  }
+
+  statement {
+    sid = "AllowProcessorToReceiveDeleteEvents"
+
+    actions = [
+      "SQS:DeleteMessage",
+      "SQS:ReceiveMessage",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        var.processing_role_arn
+      ]
+    }
+
+    resources = [
+      aws_sqs_queue.this.arn
+    ]
+  }
+}

--- a/modules/bucket-notification-queue/variables.tf
+++ b/modules/bucket-notification-queue/variables.tf
@@ -1,0 +1,30 @@
+variable "queue_name" {
+  type        = string
+  description = "The name of the queue."
+}
+
+variable "processing_role_arn" {
+  type        = string
+  description = "The arn of the role that will be able to process events sent to the queue."
+
+  validation {
+    error_message = "The value must be the arn of an AWS role."
+    condition     = regex("^arn:aws:iam::\\d{12}?:role/[\\w+=,.@-]{1,64}$", var.processing_role_arn)
+  }
+}
+
+variable "publishing_bucket_arn" {
+  type        = string
+  description = "The arn of the S3 bucket that will publish events."
+
+  validation {
+    error_message = "The value must be the arn of an S3 bucket."
+    condition     = regex("^arn:aws:s3:::[\\w+=,.@-]{3,63}$", var.publishing_bucket_arn)
+  }
+}
+
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags that will be applied to provisioned resources."
+}

--- a/modules/bucket-notification-queue/variables.tf
+++ b/modules/bucket-notification-queue/variables.tf
@@ -9,7 +9,7 @@ variable "processing_role_arn" {
 
   validation {
     error_message = "The value must be the arn of an AWS role."
-    condition     = regex("^arn:aws:iam::\\d{12}?:role/[\\w+=,.@-]{1,64}$", var.processing_role_arn)
+    condition     = can(regex("^arn:aws:iam::\\d{12}?:role/[\\w+=,.@-]{1,64}$", var.processing_role_arn))
   }
 }
 
@@ -19,7 +19,7 @@ variable "publishing_bucket_arn" {
 
   validation {
     error_message = "The value must be the arn of an S3 bucket."
-    condition     = regex("^arn:aws:s3:::[\\w+=,.@-]{3,63}$", var.publishing_bucket_arn)
+    condition     = can(regex("^arn:aws:s3:::[\\w+=,.@-]{3,63}$", var.publishing_bucket_arn))
   }
 }
 

--- a/modules/bucket-notification-queue/versions.tf
+++ b/modules/bucket-notification-queue/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.74.1"
+    }
+  }
+}

--- a/modules/standard-user/variables.tf
+++ b/modules/standard-user/variables.tf
@@ -22,6 +22,13 @@ variable "email" {
 }
 
 
+variable "cjsm_email" {
+  type        = string
+  description = "The users cjsm email address. Used for sending credentials."
+  default     = ""
+}
+
+
 variable "group_membership" {
   type        = list(string)
   description = "A list of groups that the user will be added to. Every user will automatically be added to the MFA group."
@@ -54,6 +61,7 @@ locals {
     {
       organisation = var.organisation
       email        = var.email
+      cjsm_email   = var.cjsm_email
       name         = var.full_name
     }
   )


### PR DESCRIPTION
This creates an SQS queue that can only be published to by a single S3 bucket in the same AWS Account and that can be processed (receive / delete messages) by a single AWS IAM role. 