### PR TITLE
ELM-1137: Update security operations role to allow additional access

### DIFF
--- a/modules/security-operations-centre-role/README.md
+++ b/modules/security-operations-centre-role/README.md
@@ -6,10 +6,11 @@ Currently supported:
 - Processing of logs in the shared logging environment
   - Access to S3 Buckets containing logs of security events
   - Access to SQS Queues containing notifications of S3 Object Created Events
+- Processing of security events from AWS APIs
+  - SecurityHub
+- Asset collection
+  - EC2 Instance Metadata
 
 Possible additions:
 - Processing of security events from AWS APIs
   - GuardDuty
-  - SecurityHub
-- Asset collection
-  - EC2 Instance Metadata

--- a/modules/security-operations-centre-role/main.tf
+++ b/modules/security-operations-centre-role/main.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "test-attach" {
+resource "aws_iam_role_policy_attachment" "this" {
   role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.this.arn
 }

--- a/modules/security-operations-centre-role/policy.tf
+++ b/modules/security-operations-centre-role/policy.tf
@@ -11,7 +11,23 @@ locals {
 
       resources = formatlist("%s/*", var.s3_access.bucket_arns)
     }
+  }
 
+  ec2_asset_collection = {
+    EC2AssetCollection = {
+      effect = "Allow"
+
+      actions = [
+        "ec2:DescribeInsights",
+        "ec2:DescribeRegions",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
   }
 
   list_s3_objects = {
@@ -25,7 +41,6 @@ locals {
 
       resources = var.s3_access.bucket_arns
     }
-
   }
 
   process_sqs_messages = {
@@ -39,13 +54,35 @@ locals {
 
       resources = var.sqs_access.queue_arns
     }
+  }
 
+  security_hub_api = {
+    ProcessSecurityHubFindings = {
+      effect = "Allow"
+
+      actions = [
+        "securityhub:BatchUpdateFindings",
+        "securityhub:DescribeProducts",
+        "securityhub:DescribeStandards",
+        "securityhub:DescribeStandardsControls",
+        "securityhub:GetEnabledStandards",
+        "securityhub:GetFindings",
+        "securityhub:GetInsights",
+        "securityhub:GetInsightResults",
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
   }
 
   policy_statements = merge(
     [local.download_s3_objects, {}][var.s3_access.enabled ? 0 : 1],
+    [local.ec2_asset_collection, {}][var.enable_ec2_asset_collection ? 0 : 1],
     [local.list_s3_objects, {}][var.s3_access.enabled ? 0 : 1],
     [local.process_sqs_messages, {}][var.sqs_access.enabled ? 0 : 1],
+    [local.security_hub_api, {}][var.enable_security_hub_access ? 0 : 1],
   )
 }
 

--- a/modules/security-operations-centre-role/variables.tf
+++ b/modules/security-operations-centre-role/variables.tf
@@ -3,8 +3,20 @@ variable "name_prefix" {
   type        = string
 }
 
+variable "enable_security_hub_access" {
+  description = "Attach a policy statement that enables access to the security hub api."
+  type        = bool
+  default     = false
+}
+
+variable "enable_ec2_asset_collection" {
+  description = "Attach a policy statement that enables access to ec2 metadata"
+  type        = bool
+  default     = false
+}
+
 variable "s3_access" {
-  description = "Attach a policy to the role that enables access to the specified S3 buckets"
+  description = "Attach a policy to the role that enables access to the specified S3 buckets."
   type = object({
     enabled     = bool
     bucket_arns = list(string)


### PR DESCRIPTION
This updates the role to add the additional optional access required by the SOC provider in each AWS account.