### PR TITLE
ELM-1137: Limit the characters used in external ids

### DIFF
--- a/modules/security-operations-centre-role/main.tf
+++ b/modules/security-operations-centre-role/main.tf
@@ -9,6 +9,7 @@ resource "aws_iam_role" "this" {
 resource "random_string" "externalid" {
   length  = 16
   special = true
+  override_special = "+=,.@:/-"
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {

--- a/modules/security-operations-centre-role/main.tf
+++ b/modules/security-operations-centre-role/main.tf
@@ -7,8 +7,8 @@ resource "aws_iam_role" "this" {
 
 // ExternalId is visible in the console, no point in making it secret
 resource "random_string" "externalid" {
-  length  = 16
-  special = true
+  length           = 16
+  special          = true
   override_special = "+=,.@:/-"
 }
 


### PR DESCRIPTION
Per the AWS [docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html):
> The external ID value that a third party uses to assume a role must have a minimum of 2 characters and a maximum of 1,224 characters. The value must be alphanumeric without white space. It can also include the following symbols: plus (+), equal (=), comma (,), period (.), at (@), colon (:), forward slash (/), and hyphen (-).
