### PR TITLE
ELM-1137: Allow the soc to get the queue url to receive messages

### DIFF
--- a/modules/security-operations-centre-role/policy.tf
+++ b/modules/security-operations-centre-role/policy.tf
@@ -65,6 +65,7 @@ locals {
 
       actions = [
         "sqs:DeleteMessage",
+        "sqs:GetQueueUrl",
         "sqs:ReceiveMessage",
       ]
 


### PR DESCRIPTION
The ReceiveMessage SQS API action requires the queue url as a parameter of the request. Adding this permission allows the SOC to get the queue url themselves.