### PR TITLE
Elm 585/notify slack

### DIFF
--- a/modules/slack-notify/README.md
+++ b/modules/slack-notify/README.md
@@ -1,3 +1,3 @@
 # Notify Slack Lambda
 
-A module to define a lambda to send alarms to slack without remaking the alarm topic. Takes in a the current account and tags. 
+A module to define a lambda to send alarms to slack without remaking the alarm topic. Takes in a the current account and tags.

--- a/modules/slack-notify/README.md
+++ b/modules/slack-notify/README.md
@@ -1,0 +1,3 @@
+# Notify Slack Lambda
+
+A module to define a lambda to send alarms to slack without remaking the alarm topic. Takes in a the current account and tags. 

--- a/modules/slack-notify/main.tf
+++ b/modules/slack-notify/main.tf
@@ -72,7 +72,7 @@ module "notify_slack" {
 
   lambda_role = "arn:aws:iam::${var.current_account}:role/lambda20200305133159295200000001"
 
-  slack_webhook_url = ${{ secrets.SLACK_WEBHOOK_URL }}
+  slack_webhook_url = secrets.SLACK_WEBHOOK_URL
   slack_channel     = "elmon-aws-alerts"
   slack_username    = var.current_account
   tags              = var.tags

--- a/modules/slack-notify/main.tf
+++ b/modules/slack-notify/main.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "this" {
-    name = "lambda20200305133159295200000001"
-    assume_role_policy = data.aws_iam_policy_document.this.json
-    tags = var.tags
+  name               = "lambda20200305133159295200000001"
+  assume_role_policy = data.aws_iam_policy_document.this.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "this" {
@@ -17,9 +17,9 @@ data "aws_iam_policy_document" "this" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  name = "lambda-policy-20200305133200561500000002"
+  name        = "lambda-policy-20200305133200561500000002"
   description = "Gives the lambda access to write cloudwatch logs"
-  role = aws_iam_role.lambda20200305133159295200000001.id
+  role        = aws_iam_role.lambda20200305133159295200000001.id
   policy = jsonencode({
     Statement = [{
       Sid    = "AllowWriteToCloudwatchLogs"
@@ -58,9 +58,9 @@ data "aws_iam_policy_document" "topic_assume_policy" {
 }
 
 resource "aws_sns_topic" "alarm-topic-slack" {
-  name                                     = "alarms-topic-slack"
-  tags                                     = var.tags
-  policy                                   = data.aws_iam_policy_document.topic_assume_policy.json
+  name   = "alarms-topic-slack"
+  tags   = var.tags
+  policy = data.aws_iam_policy_document.topic_assume_policy.json
 }
 
 module "notify_slack" {

--- a/modules/slack-notify/main.tf
+++ b/modules/slack-notify/main.tf
@@ -72,7 +72,7 @@ module "notify_slack" {
 
   lambda_role = "arn:aws:iam::${var.current_account}:role/lambda20200305133159295200000001"
 
-  slack_webhook_url = "https://hooks.slack.com/services/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"
+  slack_webhook_url = ${{ secrets.SLACK_WEBHOOK_URL }}
   slack_channel     = "elmon-aws-alerts"
   slack_username    = var.current_account
   tags              = var.tags

--- a/modules/slack-notify/main.tf
+++ b/modules/slack-notify/main.tf
@@ -1,0 +1,79 @@
+resource "aws_iam_role" "this" {
+    name = "lambda20200305133159295200000001"
+    assume_role_policy = data.aws_iam_policy_document.this.json
+    tags = var.tags
+}
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "this" {
+  name = "lambda-policy-20200305133200561500000002"
+  description = "Gives the lambda access to write cloudwatch logs"
+  role = aws_iam_role.lambda20200305133159295200000001.id
+  policy = jsonencode({
+    Statement = [{
+      Sid    = "AllowWriteToCloudwatchLogs"
+      Effect = "Allow"
+      Action = [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream"
+      ]
+      Resource = "arn:aws:logs:eu-west-2:${var.current_account}:log-group:/aws/lambda/notify_slack:*"
+      Version  = "2012-10-17"
+    }]
+  })
+}
+
+data "aws_iam_policy_document" "topic_assume_policy" {
+  statement {
+    sid    = "__default_statement_ID"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:GetTopicAttributes",
+      "SNS:SetTopicAttributes",
+      "SNS:AddPermission",
+      "SNS:RemovePermission",
+      "SNS:DeleteTopic",
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Publish",
+      "SNS:Receive"
+    ]
+    resources = ["arn:aws:sns:eu-west-2:${var.current_account}:alarms-topic-slack"]
+  }
+}
+
+resource "aws_sns_topic" "alarm-topic-slack" {
+  name                                     = "alarms-topic-slack"
+  tags                                     = var.tags
+  policy                                   = data.aws_iam_policy_document.topic_assume_policy.json
+}
+
+module "notify_slack" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 6.4"
+
+  sns_topic_name   = "alarms-topic-slack"
+  create_sns_topic = false
+
+  lambda_role = "arn:aws:iam::${var.current_account}:role/lambda20200305133159295200000001"
+
+  slack_webhook_url = "https://hooks.slack.com/services/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"
+  slack_channel     = "elmon-aws-alerts"
+  slack_username    = var.current_account
+  tags              = var.tags
+}

--- a/modules/slack-notify/main.tf
+++ b/modules/slack-notify/main.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role_policy" "this" {
         "logs:PutLogEvents",
         "logs:CreateLogStream"
       ]
-      Resource = "arn:aws:logs:eu-west-2:${var.current_account}:log-group:/aws/lambda/notify_slack:*"
+      Resource = "arn:aws:logs:eu-west-2:${var.account_number}:log-group:/aws/lambda/notify_slack:*"
       Version  = "2012-10-17"
     }]
   })
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "topic_assume_policy" {
       "SNS:Publish",
       "SNS:Receive"
     ]
-    resources = ["arn:aws:sns:eu-west-2:${var.current_account}:alarms-topic-slack"]
+    resources = ["arn:aws:sns:eu-west-2:${var.account_number}:alarms-topic-slack"]
   }
 }
 
@@ -70,7 +70,7 @@ module "notify_slack" {
   sns_topic_name   = "alarms-topic-slack"
   create_sns_topic = false
 
-  lambda_role = "arn:aws:iam::${var.current_account}:role/lambda20200305133159295200000001"
+  lambda_role = "arn:aws:iam::${var.account_number}:role/lambda20200305133159295200000001"
 
   slack_webhook_url = secrets.SLACK_WEBHOOK_URL
   slack_channel     = "elmon-aws-alerts"

--- a/modules/slack-notify/variables.tf
+++ b/modules/slack-notify/variables.tf
@@ -1,9 +1,9 @@
 variable "current_account" {
-    description = "Account number for use in the arns"
-    type = string
+  description = "Account number for use in the arns"
+  type        = string
 }
 
 variable "tags" {
-    type = map(string)
-    description = "A map of tags that will be applied to provisioned resources."
+  type        = map(string)
+  description = "A map of tags that will be applied to provisioned resources."
 }

--- a/modules/slack-notify/variables.tf
+++ b/modules/slack-notify/variables.tf
@@ -9,6 +9,6 @@ variable "tags" {
 }
 
 variable "current_account" {
-    description = "Account name prefix"
-    type        = string
+  description = "Account name prefix"
+  type        = string
 }

--- a/modules/slack-notify/variables.tf
+++ b/modules/slack-notify/variables.tf
@@ -1,4 +1,4 @@
-variable "current_account" {
+variable "account_number" {
   description = "Account number for use in the arns"
   type        = string
 }
@@ -6,4 +6,9 @@ variable "current_account" {
 variable "tags" {
   type        = map(string)
   description = "A map of tags that will be applied to provisioned resources."
+}
+
+variable "current_account" {
+    description = "Account name prefix"
+    type        = string
 }

--- a/modules/slack-notify/variables.tf
+++ b/modules/slack-notify/variables.tf
@@ -1,0 +1,9 @@
+variable "current_account" {
+    description = "Account number for use in the arns"
+    type = string
+}
+
+variable "tags" {
+    type = map(string)
+    description = "A map of tags that will be applied to provisioned resources."
+}


### PR DESCRIPTION
Creates a module for notify slack lambda without deleting the SNS alarm topic as this is tied to many components already.